### PR TITLE
Corrected links that previously went nowhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 > Easier installation of Node.js packages irrespective of the platform or package manager.
 
-- Supports [npm](npmjs.com) and [yarn](yarnpkg.com)
+- Supports [npm](https://www.npmjs.com) and [yarn](https://www.yarnpkg.com)
 - Easy to use promise-based API
-- Uses [`execa`](npm.im/execa) under the hood
+- Uses [`execa`](https://www.npm.im/execa) under the hood
 
 ## Installation
 


### PR DESCRIPTION
These links previously would link relative to the repository, and since these files did not exist, you would get a 404.
This should make the links work perfectly well if clicked on.